### PR TITLE
refactor socket wrapper

### DIFF
--- a/src/net/http_session.cc
+++ b/src/net/http_session.cc
@@ -18,12 +18,13 @@ const char* kHeader = "HTTP/1.1 200 OK\r\n"
                       "Content-Length: 85\r\n"
                       "Server:elitk/Manjaro 20.0 - Lysia\r\n"
                       "\r\n"
-                      "<!DOCTYPE html><html><head> Welcom, Kai</head><h1> aaa, elitk's Home page</h1></html>";
+                      "<!DOCTYPE html><html><head> Welcom, Kai</head><h1> Hi, Home page by Kai Li</h1></html>";
 
 
-HttpSession::HttpSession(SocketWrapper socket) : socket_(std::move(socket))
-{}
-
+HttpSession::HttpSession(SOCKET socket) : socket_(socket)
+{
+    socket_.ToNonBlockMode();
+}
 
 HttpSession::~HttpSession()
 {
@@ -47,10 +48,9 @@ void HttpSession::Read()
 
 void HttpSession::Send()
 {
-    socket_.SetSendData(kHeader, strlen(kHeader));
     socket_.SetOnDoneCallback([&](){ OnSendDone(); });
     socket_.SetOnErrorCallback([&](int err_no){ OnError(err_no); });
-    socket_.StartSend();
+    socket_.Send(kHeader, strlen(kHeader));
 }
 
 
@@ -87,7 +87,6 @@ void HttpSession::DoRead(std::string& data)
 
 void HttpSession::OnSendDone()
 {
-    socket_.StopSend();
     Close();
 }
 
@@ -103,7 +102,6 @@ void HttpSession::OnError(int err_no)
             socket_.StopRead();
         case Status::kSendResponseHeader:
         case Status::kSendResponseData:
-            socket_.StopSend();
             break;
     }
     Close();

--- a/src/net/http_session.h
+++ b/src/net/http_session.h
@@ -26,7 +26,7 @@ enum class Status : int
 class HttpSession
 {
 public:
-    explicit HttpSession(SocketWrapper socket);
+    explicit HttpSession(SOCKET socket);
     ~HttpSession();
 
     HttpSession(HttpSession&&) = delete;

--- a/src/net/socket_wrapper.hpp
+++ b/src/net/socket_wrapper.hpp
@@ -10,41 +10,33 @@ using SOCKET = int;
 #endif
 
 
+using OnReadCallback = std::function<void()>;
+using OnDataCallback = std::function<void(std::string& data)>;
+using OnDoneCallback = std::function<void()>;
+using OnErrorCallback = std::function<void(int)>;
+
+
 class SocketWrapper
 {
-public:
-    using OnReadCallback = std::function<void()>;
-    using OnDataCallback = std::function<void(std::string& data)>;
-    using OnDoneCallback = std::function<void()>;
-    using OnErrorCallback = std::function<void(int)>;
-
 public:
     explicit SocketWrapper(bool IPv6 = false);
     explicit SocketWrapper(SOCKET socket);
     ~SocketWrapper();
 
-    SocketWrapper(SocketWrapper&&) noexcept;
-//    PosixSocket(const PosixSocket&);
-//    PosixSocket& operator=(PosixSocket&&) noexcept;
-//    PosixSocket& operator=(const PosixSocket&);
-
 public:
+    void ToNonBlockMode();
+    SOCKET GetSocket() const;
+
     void StartRead();
     void StopRead() const;
-    void SetOnReadCallback(OnReadCallback cb);
-    void SetOnDataCallback(OnDataCallback cb);
-
-    void StartSend();
-    void StopSend() const;
-    void SetSendData(const std::string& data);
-    void SetSendData(const char* data, size_t data_size);
-
-    void SetOnDoneCallback(OnDoneCallback cb);
-    void SetOnErrorCallback(OnErrorCallback cb);
-
+    void Send(const std::string& data);
+    void Send(const char* data, size_t data_size);
     void Close();
 
-    SOCKET GetSocket() const { return socket_; }
+    void SetOnReadCallback(OnReadCallback cb);
+    void SetOnDataCallback(OnDataCallback cb);
+    void SetOnDoneCallback(OnDoneCallback cb);
+    void SetOnErrorCallback(OnErrorCallback cb);    
 
 private:
     void DoSend();
@@ -54,13 +46,12 @@ private:
     SOCKET socket_{};
 
     std::size_t sent_len_{};
-    std::size_t recv_len_{};
+    // std::size_t recv_len_{};
     std::string send_buffer_{};
     std::string recv_buffer_{};
 
     OnReadCallback on_read_{};
     OnDataCallback on_data_{};
-
     OnDoneCallback on_done_{};
     OnErrorCallback on_error_{};
 };


### PR DESCRIPTION
1. Fix wrong read/write logic.
2.  Using LOG instead of std::cerr
3.  Clear code.